### PR TITLE
fix: support WebSocket upgrades and stop relay listener flapping

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -784,4 +784,95 @@ func TestProxy_CountingReadCloser_And_ResponseWriter(t *testing.T) {
 	}
 }
 
+func TestProxy_CountingResponseWriter_PreservesHTTPInterfaces(t *testing.T) {
+	var bytesOut atomic.Uint64
+	rec := httptest.NewRecorder()
+	crw := &countingResponseWriter{ResponseWriter: rec, written: &bytesOut}
+
+	// Compile-time assertions: the wrapper must keep satisfying the optional
+	// interfaces httputil.ReverseProxy relies on for WebSocket upgrades and
+	// streaming responses.
+	var _ http.Flusher = crw
+	var _ http.Hijacker = crw
+	var _ http.CloseNotifier = crw
+
+	// Runtime: delegate to the underlying writer. httptest.ResponseRecorder
+	// supports Flush but not Hijack, so Hijack must surface an error instead
+	// of panicking.
+	crw.Flush()
+	if _, _, err := crw.Hijack(); err == nil {
+		t.Error("expected Hijack() to fail when underlying writer lacks http.Hijacker")
+	}
+}
+
+func TestProxy_Relay_PersistsAcrossReconciles(t *testing.T) {
+	// Regression test: a relay listener must NOT be recycled as "backend down"
+	// just because its own [::]:port now appears as one of our listeners.
+	probe, err := listenV6Only(0)
+	if err != nil {
+		t.Skipf("IPv6 unavailable: %v", err)
+	}
+	_ = probe.Close()
+
+	// Acquire a free port to act as the v4-only backend.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	backendPort := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+
+	tempDir := t.TempDir()
+	autoTrue := true
+	autoFalse := false
+	cfg := &config.Config{
+		PollSeconds: 1,
+		GracePolls:  2,
+		HTTPSAuto:   &autoFalse,
+		Relay:       config.RelayCfg{Auto: autoTrue},
+	}
+	cm := cert.NewManager("", "localhost", tempDir, true, false, "", "", "")
+	_ = cm.Refresh()
+	lg := logger.New()
+	srv := NewService(cfg, lg, cm)
+	defer srv.Shutdown()
+
+	// 1st reconcile creates the relay listener.
+	srv.Reconcile(&scanner.Result{
+		V4Wild:   map[int]bool{backendPort: true},
+		V6Any:    map[int]bool{},
+		V6Others: map[int]bool{},
+		PIDs:     map[int]int{},
+		Names:    map[int]string{},
+	})
+
+	// Subsequent scans report our own [::]:backendPort relay as an active
+	// V6Any socket, exactly like the real procfs scanner would.
+	for i := 0; i < 20; i++ {
+		srv.Reconcile(&scanner.Result{
+			V4Wild:   map[int]bool{backendPort: true},
+			V6Any:    map[int]bool{backendPort: true},
+			V6Others: map[int]bool{},
+			PIDs:     map[int]int{backendPort: 9999},
+			Names:    map[int]string{backendPort: "nasconnplus"},
+		})
+	}
+
+	relayKey := fmt.Sprintf("relay:%d", backendPort)
+	srv.mu.Lock()
+	st, ok := srv.listeners[relayKey]
+	missing := srv.missing[relayKey]
+	srv.mu.Unlock()
+
+	if !ok {
+		t.Fatalf("relay listener %s was recycled (flap bug)", relayKey)
+	}
+	if st.conflict {
+		t.Fatalf("relay listener %s ended up in conflict state", relayKey)
+	}
+	if missing >= cfg.GracePolls {
+		t.Fatalf("relay listener %s accumulating teardown polls (missing=%d)", relayKey, missing)
+	}
+}
+
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -259,14 +260,18 @@ func (s *Service) Reconcile(res *scanner.Result) {
 	if s.cfg.HTTPSAuto != nil && *s.cfg.HTTPSAuto {
 		allActivePorts := make(map[int]bool)
 		for port := range res.V4Wild {
-			// CRITICAL: Never treat our own listener ports as new HTTP targets to upgrade!
-			if !s.isOurListenerPortLocked(port) && !s.isExcluded(port) && s.isHTTPSAllowed(port) {
+			// CRITICAL: Never treat our own non-relay listener ports as new HTTP
+			// targets to upgrade. Relay-owned ports are real v4-only backends and
+			// remain valid HTTP upgrade candidates.
+			if (!s.isOurListenerPortLocked(port) || s.isOurListener("relay", port)) && !s.isExcluded(port) && s.isHTTPSAllowed(port) {
 				allActivePorts[port] = true
 			}
 		}
 		for port := range res.V6Any {
-			// CRITICAL: Never treat our own listener ports as new HTTP targets to upgrade!
-			if !s.isOurListenerPortLocked(port) && !s.isExcluded(port) && s.isHTTPSAllowed(port) {
+			// CRITICAL: Never treat our own non-relay listener ports as new HTTP
+			// targets to upgrade. Relay-owned ports are real v4-only backends and
+			// remain valid HTTP upgrade candidates.
+			if (!s.isOurListenerPortLocked(port) || s.isOurListener("relay", port)) && !s.isExcluded(port) && s.isHTTPSAllowed(port) {
 				allActivePorts[port] = true
 			}
 		}
@@ -323,8 +328,10 @@ func (s *Service) Reconcile(res *scanner.Result) {
 			if s.isExcluded(port) || !s.isRelayAllowed(port) || res.V6Others[port] {
 				continue
 			}
-			// Do not relay our own listener ports
-			if s.isOurListenerPortLocked(port) {
+			// Do not relay ports already claimed by our own non-relay listeners
+			// (e.g. an HTTPS listener on :P). A relay's own port must remain a
+			// desired target, otherwise it would be recycled every reconcile.
+			if s.isOurListenerPortLocked(port) && !s.isOurListener("relay", port) {
 				continue
 			}
 			wants[key("relay", port)] = want{
@@ -678,6 +685,37 @@ func (w *countingResponseWriter) Write(b []byte) (int, error) {
 	if n > 0 {
 		w.written.Add(uint64(n))
 	}
+	return n, err
+}
+
+func (w *countingResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *countingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("underlying ResponseWriter does not implement http.Hijacker")
+	}
+	return hj.Hijack()
+}
+
+func (w *countingResponseWriter) CloseNotify() <-chan bool {
+	if cn, ok := w.ResponseWriter.(http.CloseNotifier); ok {
+		return cn.CloseNotify()
+	}
+	return nil
+}
+
+func (w *countingResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := w.ResponseWriter.(io.ReaderFrom); ok {
+		n, err := rf.ReadFrom(r)
+		w.written.Add(uint64(n))
+		return n, err
+	}
+	n, err := io.Copy(w, r)
 	return n, err
 }
 


### PR DESCRIPTION
Two production bugs surfaced during deployment verification:

1. HTTPS WebSocket upgrades always failed with 'can't switch protocols using non-Hijacker ResponseWriter'. countingResponseWriter only implemented Write(), so it dropped the http.Hijacker/http.Flusher/http.CloseNotifier capabilities the httputil.ReverseProxy needs for WebSocket and streaming. Delegate these interfaces to the underlying ResponseWriter.

2. Relay and auto-HTTP listeners were recycled every reconcile as 'backend down'. isOurListenerPortLocked() treated a relay's own [::]:port as an already-occupied listener, so the relay's desired state was never satisfied and it was torn down after grace_polls, permanently killing long-lived connections. Only skip relay/auto candidates claimed by our own non-relay listeners.

## 变更类型 (Type of Change)
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🧪 测试用例补充 (Add/Update tests)
- [ ] ⚡ 性能优化 / 代码重构 (Performance/Refactoring)
- [ ] 🔧 构建/CI 依赖配置 (Build/CI tooling)

## 变更描述 (Description)
简要说明本次 PR 解决的问题或实现的功能。

## 关联 Issue (Related Issue)
Fixes # (如无关联 Issue 可留空)

## 验证与测试 (Verification & Testing)
请勾选确认已执行的自测步骤：
- [ ] 本地单元测试通过：`make test`
- [ ] 代码覆盖率检查通过：`make test-coverage`
- [ ] 静态代码分析通过：`make lint`
- [ ] （如适用）本地已在真实或模拟网络环境下验证功能

## Checklist
- [ ] 代码遵循 Go 语言官方规范与项目现有风格
- [ ] 为新增或修改的核心逻辑编写了测试用例
- [ ] 更新了相关的文档说明（如 README 或注释）
- [ ] Commit 信息符合规范
