### PR TITLE
feat(proxy,cert): dynamic SNI dispatch, relax header timeout and normalize OpenAI paths

### DIFF
--- a/internal/cert/cert.go
+++ b/internal/cert/cert.go
@@ -31,6 +31,7 @@ type Manager struct {
 	autoTrustErr error
 	acmeMgr      *autocert.Manager
 	cur          *tls.Certificate
+	certMap      map[string]*tls.Certificate
 	loadedAt     string
 	trustedCA    string
 }
@@ -44,6 +45,7 @@ func NewManager(cfgPath, host, selfDir string, fallback bool, acmeEnabled bool, 
 		fallback:    fallback,
 		acmeEnabled: acmeEnabled,
 		acmeDomain:  acmeDomain,
+		certMap:     make(map[string]*tls.Certificate),
 	}
 
 	if acmeEnabled && acmeDomain != "" {
@@ -72,6 +74,13 @@ func (m *Manager) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, 
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	// SNI match
+	if hello != nil && hello.ServerName != "" && len(m.certMap) > 0 {
+		if c, ok := m.certMap[hello.ServerName]; ok && c != nil {
+			return c, nil
+		}
+	}
 
 	if m.cur != nil {
 		return m.cur, nil
@@ -166,6 +175,9 @@ func (m *Manager) Refresh() error {
 	var lastErr error
 
 	if cfgPath != "" {
+		// Also parse all entries into certMap for dynamic SNI dispatch
+		m.loadAllCertEntries(cfgPath)
+
 		certFile, keyFile, err := m.resolveCertFilesWith(cfgPath, host)
 		if err == nil {
 			fp := m.certFingerprint(certFile, keyFile)
@@ -262,6 +274,30 @@ func (m *Manager) Refresh() error {
 		lastErr = fmt.Errorf("no certificate source configured and self-signed fallback disabled")
 	}
 	return lastErr
+}
+
+func (m *Manager) loadAllCertEntries(cfgPath string) {
+	b, err := os.ReadFile(filepath.Clean(cfgPath))
+	if err != nil {
+		return
+	}
+	var entries []CertEntry
+	if err := json.Unmarshal(b, &entries); err != nil || len(entries) == 0 {
+		return
+	}
+
+	newMap := make(map[string]*tls.Certificate)
+	for _, e := range entries {
+		if e.Host != "" && e.Host != "fallback" && e.Host != "*" && e.Cert != "" && e.Key != "" {
+			if kc, err := tls.LoadX509KeyPair(e.Cert, e.Key); err == nil {
+				newMap[e.Host] = &kc
+			}
+		}
+	}
+
+	m.mu.Lock()
+	m.certMap = newMap
+	m.mu.Unlock()
 }
 
 func (m *Manager) resolveCertFilesWith(cfgPath, host string) (string, string, error) {

--- a/internal/cert/cert_test.go
+++ b/internal/cert/cert_test.go
@@ -408,6 +408,46 @@ func TestCertManager_GetCertificate(t *testing.T) {
 	if cert == nil {
 		t.Fatal("expected non-nil cert")
 	}
+
+	// 3. Dynamic SNI multi-cert resolution
+	cfgSNI := filepath.Join(tempDir, "sni_cert.json")
+	certA, keyA := filepath.Join(tempDir, "a.crt"), filepath.Join(tempDir, "a.key")
+	certB, keyB := filepath.Join(tempDir, "b.crt"), filepath.Join(tempDir, "b.key")
+	if _, _, _, err := loadOrCreateLocalSignedCertificate(tempDir, "app-a.local"); err != nil {
+		t.Fatalf("gen a: %v", err)
+	}
+	_ = os.Rename(filepath.Join(tempDir, "selfsigned.crt"), certA)
+	_ = os.Rename(filepath.Join(tempDir, "selfsigned.key"), keyA)
+
+	if _, _, _, err := loadOrCreateLocalSignedCertificate(tempDir, "app-b.local"); err != nil {
+		t.Fatalf("gen b: %v", err)
+	}
+	_ = os.Rename(filepath.Join(tempDir, "selfsigned.crt"), certB)
+	_ = os.Rename(filepath.Join(tempDir, "selfsigned.key"), keyB)
+
+	sniEntries := []CertEntry{
+		{Host: "fallback", Cert: certA, Key: keyA},
+		{Host: "app-a.local", Cert: certA, Key: keyA},
+		{Host: "app-b.local", Cert: certB, Key: keyB},
+	}
+	bSNI, _ := json.Marshal(sniEntries)
+	_ = os.WriteFile(cfgSNI, bSNI, 0o644)
+
+	cmSNI := NewManager(cfgSNI, "app-a.local", tempDir, false, false, "", "", "")
+	if err := cmSNI.Refresh(); err != nil {
+		t.Fatalf("cmSNI refresh: %v", err)
+	}
+
+	// Test SNI dispatch to app-b
+	certAppB, err := cmSNI.GetCertificate(&tls.ClientHelloInfo{ServerName: "app-b.local"})
+	if err != nil || certAppB == nil {
+		t.Fatalf("expected app-b cert, got err=%v", err)
+	}
+	// Test SNI dispatch to unknown host -> falls back to cur
+	certFallback, err := cmSNI.GetCertificate(&tls.ClientHelloInfo{ServerName: "unknown.local"})
+	if err != nil || certFallback == nil {
+		t.Fatalf("expected fallback cert, got err=%v", err)
+	}
 }
 
 func TestCertManager_ResolveCertFiles_Errors(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,8 +92,9 @@ type Config struct {
 	HTTPS                   []HTTPSPort `json:"https"`         // Explicit custom rules (optional overrides)
 	Relay                   RelayCfg    `json:"relay"`
 	MaxConnsPerListener     int         `json:"max_conns_per_listener"`
-	SocketPath              string      `json:"socket_path"`
-	OverrideDefaultExcludes bool        `json:"override_default_excludes"`
+	SocketPath                   string      `json:"socket_path"`
+	OverrideDefaultExcludes      bool        `json:"override_default_excludes"`
+	ResponseHeaderTimeoutSeconds int         `json:"response_header_timeout_seconds"` // Default: 300 (seconds)
 
 	relayExcludeSet map[int]struct{} `json:"-"`
 	httpsExcludeSet map[int]struct{} `json:"-"`

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -88,6 +88,15 @@ func NewService(cfg *config.Config, log *logger.Logger, certs *cert.Manager) *Se
 		warnedConflict: make(map[string]time.Time),
 	}
 
+	respHeaderTimeout := 300 * time.Second
+	if cfg != nil {
+		if cfg.ResponseHeaderTimeoutSeconds > 0 {
+			respHeaderTimeout = time.Duration(cfg.ResponseHeaderTimeoutSeconds) * time.Second
+		} else if cfg.ResponseHeaderTimeoutSeconds < 0 {
+			respHeaderTimeout = 0
+		}
+	}
+
 	// High performance connection pooling: tuned for NAS low-memory devices
 	// MaxIdleConns reduced from 1024 to 256 to avoid fd exhaustion on 512M NAS
 	s.transport = &http.Transport{
@@ -102,7 +111,7 @@ func NewService(cfg *config.Config, log *logger.Logger, certs *cert.Manager) *Se
 		MaxConnsPerHost:        32,
 		IdleConnTimeout:        90 * time.Second,
 		TLSHandshakeTimeout:    5 * time.Second,
-		ResponseHeaderTimeout:  15 * time.Second,
+		ResponseHeaderTimeout:  respHeaderTimeout,
 		ExpectContinueTimeout:  1 * time.Second,
 		// P1: 8K broke SSO-heavy backends (large Set-Cookie chains, e.g. DSM).
 		// 32K still bounds abuse at ~300x below Go's 10M default.
@@ -400,6 +409,13 @@ func (s *Service) startHTTPServer(st *listenerState, w want) {
 		Transport:  s.transport,
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(targetURL)
+			// Automatic path normalization for OpenAI-compatible LLM endpoints:
+			// Allows clients requesting /chat/completions or /models to work without /v1 prefix.
+			if pr.Out.URL.Path == "/chat/completions" {
+				pr.Out.URL.Path = "/v1/chat/completions"
+			} else if pr.Out.URL.Path == "/models" {
+				pr.Out.URL.Path = "/v1/models"
+			}
 			pr.Out.Host = pr.In.Host
 			pr.SetXForwarded()
 			pr.Out.Header.Set("X-Forwarded-Proto", "https")


### PR DESCRIPTION
## Overview
This PR improves TLS handshake flexibility, resilience for long-reasoning LLMs, and path compatibility for OpenAI endpoints.

### Key Changes
1. **Dynamic SNI Certificate Dispatch (`internal/cert/cert.go`)**:
   - Parses and caches certificate entries keyed by hostname (`certMap`).
   - Dynamically matches incoming `tls.ClientHelloInfo.ServerName` to serve the exact matching certificate chain, falling back to default/cur cert if unmatched.
   - Added unit test in `cert_test.go`.

2. **Relaxed Response Header Timeout (`internal/proxy/service.go`, `internal/config/config.go`)**:
   - Exposed `response_header_timeout_seconds` in `Config`.
   - Increased default `ResponseHeaderTimeout` from 15s to 300s to support long reasoning models (e.g., Gemini 3.8 / Thinking models) without unexpected EOF disconnections.

3. **OpenAI Endpoint Normalization (`internal/proxy/service.go`)**:
   - Normalizes `/chat/completions` and `/models` requests to `/v1/chat/completions` and `/v1/models` in reverse proxy rewrite.
